### PR TITLE
Time series fuel costs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -21,7 +21,8 @@ rule retrieve_supply_regions:
 
 rule retrieve_fuel_costs:
     output: 
-        fuel_costs = "data/thermal_fuel_costs.csv"
+        fuel_costs = "data/thermal_fuel_costs.csv",
+        fuel_cost_timeseries = "data/thermal_fuel_cost_ts.csv"
     script: "scripts/retrieve_fuel_prices.py"
 
 rule retrieve_costs:

--- a/Snakefile
+++ b/Snakefile
@@ -26,7 +26,8 @@ rule retrieve_fuel_costs:
 
 rule retrieve_costs:
     output: 
-        costs = "data/technology_costs.csv"
+        costs = "data/technology_costs.csv",
+        heatrates = "data/heatrates.csv"
     script: "scripts/retrieve_costs.py"
 
 rule retrieve_load:

--- a/Snakefile
+++ b/Snakefile
@@ -19,17 +19,19 @@ rule retrieve_supply_regions:
         supply_regions = "data/spatial_data/supply_regions.shp"
     script: "scripts/retrieve_supply_regions.py"
 
-rule retrieve_fuel_costs:
-    output: 
-        fuel_costs = "data/thermal_fuel_costs.csv",
-        fuel_cost_timeseries = "data/thermal_fuel_cost_ts.csv"
-    script: "scripts/retrieve_fuel_prices.py"
-
 rule retrieve_costs:
     output: 
         costs = "data/technology_costs.csv",
         heatrates = "data/heatrates.csv"
     script: "scripts/retrieve_costs.py"
+
+rule retrieve_fuel_costs:
+    input:
+        heatrates = "data/heatrates.csv"
+    output: 
+        fuel_costs = "data/thermal_fuel_costs.csv",
+        fuel_cost_timeseries = "data/thermal_fuel_cost_ts.csv"
+    script: "scripts/retrieve_fuel_prices.py"
 
 rule retrieve_load:
     output:
@@ -79,6 +81,7 @@ rule add_electricity:
         load = "data/time_series/load.csv",
         generators = "data/aggregated_generators.csv",
         costs = "data/technology_costs.csv",
+        fuel_cost_timeseries = "data/thermal_fuel_cost_ts.csv",
         wind_profile = "data/time_series/wind.csv",
         solar_profile = "data/time_series/solar.csv",
         base_network = "data/networks/base_network.nc",

--- a/Snakefile
+++ b/Snakefile
@@ -19,6 +19,11 @@ rule retrieve_supply_regions:
         supply_regions = "data/spatial_data/supply_regions.shp"
     script: "scripts/retrieve_supply_regions.py"
 
+rule retrieve_fuel_costs:
+    output: 
+        fuel_costs = "data/thermal_fuel_costs.csv"
+    script: "scripts/retrieve_fuel_prices.py"
+
 rule retrieve_costs:
     output: 
         costs = "data/technology_costs.csv"

--- a/Snakefile
+++ b/Snakefile
@@ -96,5 +96,6 @@ rule plot_results:
         dispatch_figure = f"results/{results_folder}/figures/illinois_dispatch.png",
         capacity_figure = f"results/{results_folder}/figures/illinois_capacity.png",
         emissions_figure = f"results/{results_folder}/figures/illinois_emissions.png",
-        active_units_figure = f"results/{results_folder}/figures/illinois_active_units.png"
+        active_units_figure = f"results/{results_folder}/figures/illinois_active_units.png",
+        monthly_generation_figure = f"results/{results_folder}/figures/illinois_monthly_generation.png"
     script: "scripts/plot_results.py"

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ solver: 'cplex'  # 'cplex','highs','gurobi'
 geo_res: 'rto'  # accepts: 'rto' or 'county'
 time_res: 1  # hours 
 load_filter: 60e3  # MW, load above this level will be removed as outliers.
-total_demand: 164e6  # Annual MWh in the first year
+total_demand: 185e6  # Annual MWh in the first year
 # total_demand: 136e6  # Annual MWh in the first year
 load_growth: 0.00  # % annual growth
 load_share:
@@ -29,8 +29,8 @@ co2_limits:
 # wind_years: [2009,2010,2011,2012,2013]  # WTK only goes from 2009-2013
 solar_years: [2016]  # NSRDB only accepts years 1998-2020
 wind_years: [2009]  # WTK only goes from 2009-2013
-load_year: 2023
-fuel_cost_year: 2023
+load_year: 2019
+fuel_cost_year: 2019
 
 rto_subba: ['0004','CE']  # MISO-Z4, ComEd
 region_names: ['MISO-Z4','ComEd']

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 state_abbr: 'IL'
 version: "1.0-test"
-scenario: "no_growth_with_export"
+scenario: "model_validation"
 
 solver: 'cplex'  # 'cplex','highs','gurobi'
 geo_res: 'rto'  # accepts: 'rto' or 'county'
@@ -30,7 +30,7 @@ co2_limits:
 solar_years: [2016]  # NSRDB only accepts years 1998-2020
 wind_years: [2009]  # WTK only goes from 2009-2013
 load_year: 2019
-fuel_cost_year: [2019]
+fuel_cost_year: 2023
 
 rto_subba: ['0004','CE']  # MISO-Z4, ComEd
 region_names: ['MISO-Z4','ComEd']

--- a/config.yml
+++ b/config.yml
@@ -4,9 +4,9 @@ scenario: "model_validation"
 
 solver: 'cplex'  # 'cplex','highs','gurobi'
 geo_res: 'rto'  # accepts: 'rto' or 'county'
-time_res: 4  # hours 
+time_res: 1  # hours 
 load_filter: 60e3  # MW, load above this level will be removed as outliers.
-total_demand: 185e6  # Annual MWh in the first year
+total_demand: 164e6  # Annual MWh in the first year
 # total_demand: 136e6  # Annual MWh in the first year
 load_growth: 0.00  # % annual growth
 load_share:
@@ -29,7 +29,7 @@ co2_limits:
 # wind_years: [2009,2010,2011,2012,2013]  # WTK only goes from 2009-2013
 solar_years: [2016]  # NSRDB only accepts years 1998-2020
 wind_years: [2009]  # WTK only goes from 2009-2013
-load_year: 2019
+load_year: 2023
 fuel_cost_year: 2023
 
 rto_subba: ['0004','CE']  # MISO-Z4, ComEd

--- a/config.yml
+++ b/config.yml
@@ -30,6 +30,7 @@ co2_limits:
 solar_years: [2016]  # NSRDB only accepts years 1998-2020
 wind_years: [2009]  # WTK only goes from 2009-2013
 load_year: 2019
+fuel_cost_year: [2019]
 
 rto_subba: ['0004','CE']  # MISO-Z4, ComEd
 region_names: ['MISO-Z4','ComEd']

--- a/config.yml
+++ b/config.yml
@@ -1,13 +1,13 @@
 state_abbr: 'IL'
-version: "5.0-test"
-scenario: "no_growth_no_export"
+version: "1.0-test"
+scenario: "no_growth_with_export"
 
 solver: 'cplex'  # 'cplex','highs','gurobi'
 geo_res: 'rto'  # accepts: 'rto' or 'county'
 time_res: 4  # hours 
 load_filter: 60e3  # MW, load above this level will be removed as outliers.
-# total_demand: 185e6  # Annual MWh in the first year
-total_demand: 136e6  # Annual MWh in the first year
+total_demand: 185e6  # Annual MWh in the first year
+# total_demand: 136e6  # Annual MWh in the first year
 load_growth: 0.00  # % annual growth
 load_share:
   MISO-Z4: 0.33

--- a/functions/data_functions.py
+++ b/functions/data_functions.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+
+def load_heatrates():
+    
+    heatrate_url = "https://www.eia.gov/electricity/annual/html/epa_08_01.html"
+    heatrates = pd.read_html(heatrate_url)[1].set_index("Year")
+    
+    return heatrates

--- a/functions/data_functions.py
+++ b/functions/data_functions.py
@@ -2,8 +2,8 @@ import pandas as pd
 
 
 def load_heatrates():
-    
+
     heatrate_url = "https://www.eia.gov/electricity/annual/html/epa_08_01.html"
     heatrates = pd.read_html(heatrate_url)[1].set_index("Year")
-    
+
     return heatrates

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -13,6 +13,7 @@ scale = snakemake.config['geo_res']
 idx_opts = {"rto": "balancing_authority_code",
             "county": "county"}
 growth_rates = snakemake.config['growth_rates']
+pudl_year = int(snakemake.config['fuel_cost_year'])
 
 BUILD_YEAR = 2025  # a universal build year place holder
 
@@ -67,6 +68,13 @@ def load_costs():
 
     return costs
 
+def load_costs_ts():
+    
+    fuel_costs = pd.read_csv(snakemake.input.fuel_cost_timeseries,
+                        parse_dates=True,
+                        index_col=['report_date'])
+
+    return fuel_costs
 
 def load_existing_generators():
     generators = pd.read_csv(snakemake.input.generators,
@@ -235,7 +243,8 @@ def attach_generators(
         costs,
         generators=None,
         build_years=None,
-        model_year=None):
+        model_year=None,
+        costs_ts=None):
     carriers = ['Natural Gas', 'Biomass', 'Coal', 'Nuclear', 'Petroleum']
     for bus in n.buses.index:
         for item in costs.itertuples():
@@ -291,6 +300,20 @@ def attach_generators(
                 else:
                     p_max_pu = 1
                     p_min_pu = 0
+                    
+                # time series marginal costs
+                if ((tech in ['CTAvgCF', 'CCAvgCF', 'IGCCAvgCF'])
+                    and isinstance(costs_ts, pd.DataFrame)):
+                    
+                    # select year to replicate
+                    cost_data = costs_ts.loc[str(pudl_year), carrier].values
+                    
+                    # get the VOM cost
+                    cost_data = cost_data + item.VOM
+                    
+                    marginal_cost = np.tile(cost_data, len(model_years))
+                else:
+                    marginal_cost = item.marginal_cost
 
                 n.add(class_name="Generator",
                       name=name,
@@ -302,7 +325,7 @@ def attach_generators(
                       p_max_pu=p_max_pu,
                       carrier=carrier,
                       capital_cost=item.capital_cost,
-                      marginal_cost=item.marginal_cost,
+                      marginal_cost=marginal_cost,
                       lifetime=item.lifetime,
                       ramp_limit_down=ramp_limit_down,
                       ramp_limit_up=ramp_limit_up,
@@ -364,7 +387,6 @@ if __name__ == "__main__":
 
     n = pypsa.Network(snakemake.input.base_network)
     costs = load_costs()
-
     costs.to_csv("data/final_costs.csv")
     current_costs = costs.xs((slice(None), slice(None), 2020))
     current_costs = current_costs.reset_index()
@@ -374,6 +396,7 @@ if __name__ == "__main__":
     generators = load_existing_generators()
     build_years = load_build_years()
     emissions = load_emissions()
+    costs_ts = load_costs_ts()
 
     attach_load(n)
     add_carriers(n,
@@ -389,7 +412,8 @@ if __name__ == "__main__":
     attach_generators(n,
                       costs=current_costs,
                       generators=generators,
-                      build_years=build_years
+                      build_years=build_years,
+                      costs_ts=costs_ts
                       )
     attach_storage(n,
                    costs=current_costs,
@@ -408,7 +432,8 @@ if __name__ == "__main__":
                           )
         attach_generators(n,
                           costs=current_costs,
-                          model_year=year
+                          model_year=year,
+                          costs_ts=costs_ts
                           )
         attach_storage(n,
                        costs=current_costs,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -68,13 +68,15 @@ def load_costs():
 
     return costs
 
+
 def load_costs_ts():
-    
+
     fuel_costs = pd.read_csv(snakemake.input.fuel_cost_timeseries,
-                        parse_dates=True,
-                        index_col=['report_date'])
+                             parse_dates=True,
+                             index_col=['report_date'])
 
     return fuel_costs
+
 
 def load_existing_generators():
     generators = pd.read_csv(snakemake.input.generators,
@@ -300,17 +302,17 @@ def attach_generators(
                 else:
                     p_max_pu = 1
                     p_min_pu = 0
-                    
+
                 # time series marginal costs
                 if ((tech in ['CTAvgCF', 'CCAvgCF', 'IGCCAvgCF'])
-                    and isinstance(costs_ts, pd.DataFrame)):
-                    
+                        and isinstance(costs_ts, pd.DataFrame)):
+
                     # select year to replicate
                     cost_data = costs_ts.loc[str(pudl_year), carrier].values
-                    
+
                     # get the VOM cost
                     cost_data = cost_data + item.VOM
-                    
+
                     marginal_cost = np.tile(cost_data, len(model_years))
                 else:
                     marginal_cost = item.marginal_cost

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -11,10 +11,11 @@ TECH_ORDER = ['Nuclear',
               'Solar',
               'Wind']
 
+
 def power_by_carrier(n):
     p_by_carrier = n.generators_t.p.T.groupby(
         n.generators.carrier).sum().T
-    
+
     return p_by_carrier
 
 
@@ -34,9 +35,9 @@ def plot_dispatch(n, year=2025, month=7):
     y_min = -n.storage_units_t.p_store.max().max() / 1e3
     y_max = n.loads_t.p_set.sum(axis=1).max() / 1e3
     margin = 0.1
-    y_low = (1+margin) * y_min
-    y_high = (1+margin) * y_max
-    
+    y_low = (1 + margin) * y_min
+    y_high = (1 + margin) * y_max
+
     fig, ax = plt.subplots(figsize=(12, 6))
 
     color = p_by_carrier.columns.map(n.carriers.color)
@@ -45,7 +46,7 @@ def plot_dispatch(n, year=2025, month=7):
         ax=ax,
         linewidth=0,
         color=color,
-        ylim=(y_low-margin, y_high+margin)
+        ylim=(y_low - margin, y_high + margin)
     )
 
     charge = p_by_carrier.where(
@@ -58,7 +59,7 @@ def plot_dispatch(n, year=2025, month=7):
             ax=ax,
             linewidth=0,
             color=charge.columns.map(n.carriers.color),
-            ylim=(y_low-margin,y_high+margin)
+            ylim=(y_low - margin, y_high + margin)
         )
 
     n.loads_t.p_set.sum(axis=1).loc[time].div(1e3).plot(ax=ax, c="k")
@@ -162,26 +163,26 @@ def plot_active_units(n):
 
     return fig, ax
 
+
 def plot_monthly_generation(n, time_res):
-    p_by_carrier = power_by_carrier(n) * time_res 
-    
+    p_by_carrier = power_by_carrier(n) * time_res
+
     p_by_carrier = p_by_carrier.resample('ME', level='timestep').sum()
-    
+
     p_by_carrier = p_by_carrier[TECH_ORDER]
-    
+
     color = p_by_carrier.columns.map(n.carriers.color)
-    
-    
+
     fig, ax = plt.subplots(figsize=(12, 8))
-    p_by_carrier.plot.area(ax=ax, 
+    p_by_carrier.plot.area(ax=ax,
                            color=color,
                            fontsize=16)
-    
+
     ax.set_xlabel('')
     ax.set_ylabel('Generation [MWh]', fontsize=18)
     return fig, ax
-   
-    
+
+
 if __name__ == "__main__":
 
     n = pypsa.Network(snakemake.input.solved_network)
@@ -193,13 +194,12 @@ if __name__ == "__main__":
     fig, ax = plot_capacity(n)
     plt.savefig(snakemake.output.capacity_figure)
 
-
     time_res = float(snakemake.config['time_res'])
     fig, ax = plot_emissions(n, time_res)
     plt.savefig(snakemake.output.emissions_figure)
 
     fig, ax = plot_active_units(n)
     plt.savefig(snakemake.output.active_units_figure)
-    
+
     fig, ax = plot_monthly_generation(n, time_res)
     plt.savefig(snakemake.output.monthly_generation_figure)

--- a/scripts/retrieve_costs.py
+++ b/scripts/retrieve_costs.py
@@ -92,7 +92,6 @@ if __name__ == "__main__":
 
     # converts btu/kwh to mmbtu/mwh
     ng_heatrate = heatrates.at[atb_params['atb_year'], 'Natural Gas'] / 1e3
-    # ng_heatrate =1  # converts btu/kwh to mmbtu/mwh
     coal_heatrate = heatrates.at[atb_params['atb_year'], 'Coal'] / 1e3
     petroleum_heatrate = heatrates.at[atb_params['atb_year'],
                                       'Petroleum'] / 1e3
@@ -126,3 +125,4 @@ if __name__ == "__main__":
     df_pivot.fillna(0., inplace=True)
 
     df_pivot.to_csv(snakemake.output.costs)
+    heatrates.to_csv(snakemake.output.heatrates)

--- a/scripts/retrieve_costs.py
+++ b/scripts/retrieve_costs.py
@@ -1,9 +1,11 @@
-from data_functions import load_heatrates
+import numpy as np
 import pandas as pd
 from nrelpy.atb import ATBe
 import sys
 
 sys.path.append("functions")
+from data_functions import load_heatrates
+
 
 n_illinois_reactors = 11
 total_lwr_capacity = 12415.1

--- a/scripts/retrieve_costs.py
+++ b/scripts/retrieve_costs.py
@@ -1,9 +1,9 @@
+from data_functions import load_heatrates
 import pandas as pd
 from nrelpy.atb import ATBe
 import sys
 
 sys.path.append("functions")
-from data_functions import load_heatrates
 
 n_illinois_reactors = 11
 total_lwr_capacity = 12415.1

--- a/scripts/retrieve_costs.py
+++ b/scripts/retrieve_costs.py
@@ -1,5 +1,9 @@
 import pandas as pd
 from nrelpy.atb import ATBe
+import sys
+
+sys.path.append("functions")
+from data_functions import load_heatrates
 
 n_illinois_reactors = 11
 total_lwr_capacity = 12415.1
@@ -67,8 +71,7 @@ if __name__ == "__main__":
     fuel_prices = pd.read_html(prices_url)[1].set_index(
         pd.Series(range(2012, 2023))).T
 
-    heatrate_url = "https://www.eia.gov/electricity/annual/html/epa_08_01.html"
-    heatrates = pd.read_html(heatrate_url)[1].set_index("Year")
+    heatrates = load_heatrates()
 
     price_col = 'Average Cost (Dollars per MMBtu)'
 

--- a/scripts/retrieve_fuel_prices.py
+++ b/scripts/retrieve_fuel_prices.py
@@ -31,13 +31,28 @@ def fuel_cost_pivot(dataframe):
     
     return cost_pivot
 
+def prepare_cost_timeseries(df, time_res):
+    
+    dataframe = df.copy()
+    
+    dataframe.index = pd.to_datetime(dataframe.index)
+    # remove NaN values
+    dataframe = dataframe.interpolate()
+    
+    dataframe = dataframe.resample(f'{time_res}h').ffill()
+    
+    return dataframe
 
 if __name__ == "__main__":
     
     state_abbr = snakemake.config['state_abbr']
+    time_res = snakemake.config['time_res']
     
     eia_923m_df = retrieve_eia923m_pudl(state=state_abbr)
     
     fuel_cost_df = fuel_cost_pivot(eia_923m_df)
     
     fuel_cost_df.to_csv(snakemake.output.fuel_costs)
+    
+    fuel_cost_resampled = prepare_cost_timeseries(fuel_cost_df, time_res)
+    fuel_cost_resampled.to_csv(snakemake.output.fuel_cost_timeseries)

--- a/scripts/retrieve_fuel_prices.py
+++ b/scripts/retrieve_fuel_prices.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import requests
+import numpy as np
+import json
+import os
+from dotenv import load_dotenv
+load_dotenv("../.env")
+
+
+def retrieve_eia923m_pudl(state):
+    url = (f"https://data.catalyst.coop/pudl/"
+           f"out_eia923__monthly_fuel_receipts_costs.csv?"
+           f"_labels=on&_stream=on&_sort=rowid&"
+           f"state__exact={state}&_size=max")
+    
+    df = pd.read_csv(url)
+    
+    return df
+
+
+def fuel_cost_pivot(dataframe):
+    cost_pivot = dataframe.pivot_table(index=['report_date'],
+                            columns=['fuel_type_code_pudl'],
+                            values=['fuel_cost_per_mmbtu'])
+    
+    # removes first column index, leaves the fuel name
+    cost_pivot = cost_pivot.droplevel(level=0, axis=1)
+    
+    cost_pivot = cost_pivot.rename({"coal":"Coal", 'gas':"Natural Gas", 'oil':'Petroleum'})
+    
+    return cost_pivot
+
+
+if __name__ == "__main__":
+    
+    state_abbr = snakemake.config['state_abbr']
+    
+    eia_923m_df = retrieve_eia923m_pudl(state=state_abbr)
+    
+    fuel_cost_df = fuel_cost_pivot(eia_923m_df)
+    
+    fuel_cost_df.to_csv(snakemake.output.fuel_costs)

--- a/scripts/retrieve_fuel_prices.py
+++ b/scripts/retrieve_fuel_prices.py
@@ -13,63 +13,60 @@ def retrieve_eia923m_pudl(state):
            f"out_eia923__monthly_fuel_receipts_costs.csv?"
            f"_labels=on&_stream=on&_sort=rowid&"
            f"state__exact={state}&_size=max")
-    
+
     df = pd.read_csv(url)
-    
+
     return df
 
 
 def fuel_cost_pivot(dataframe):
     cost_pivot = dataframe.pivot_table(index=['report_date'],
-                            columns=['fuel_type_code_pudl'],
-                            values=['fuel_cost_per_mmbtu'])
-    
+                                       columns=['fuel_type_code_pudl'],
+                                       values=['fuel_cost_per_mmbtu'])
+
     # removes first column index, leaves the fuel name
     cost_pivot = cost_pivot.droplevel(level=0, axis=1)
-    
-    cost_pivot = cost_pivot.rename(columns={"coal":"Coal", 
-                                            'gas':"Natural Gas", 
-                                            'oil':'Petroleum'})
-    
+
+    cost_pivot = cost_pivot.rename(columns={"coal": "Coal",
+                                            'gas': "Natural Gas",
+                                            'oil': 'Petroleum'})
+
     return cost_pivot
 
 
 def prepare_cost_timeseries(df, time_res):
-    
+
     dataframe = df.copy()
-    
+
     dataframe.index = pd.to_datetime(dataframe.index)
     # remove NaN values
     dataframe = dataframe.interpolate()
-    
+
     dataframe = dataframe.resample(f'{time_res}h').ffill()
-    
+
     return dataframe
 
 
-
 if __name__ == "__main__":
-    # config file options    
+    # config file options
     state_abbr = snakemake.config['state_abbr']
     time_res = snakemake.config['time_res']
     year = snakemake.config['fuel_cost_year']
-    
-    
+
     eia_923m_df = retrieve_eia923m_pudl(state=state_abbr)
-    
-    fuel_cost_df = fuel_cost_pivot(eia_923m_df)    
-    heatrates = pd.read_csv(snakemake.input.heatrates, 
-                            parse_dates=True, 
+
+    fuel_cost_df = fuel_cost_pivot(eia_923m_df)
+    heatrates = pd.read_csv(snakemake.input.heatrates,
+                            parse_dates=True,
                             index_col='Year')
-    
-    
+
     heatrates[fuel_cost_df.columns]
-    
-    vals = heatrates.loc[heatrates.index[-1], 
+
+    vals = heatrates.loc[heatrates.index[-1],
                          fuel_cost_df.columns].to_frame().T.values[0] / 1e3
 
-    fuel_cost_df = fuel_cost_df*vals
-    
+    fuel_cost_df = fuel_cost_df * vals
+
     fuel_cost_df.to_csv(snakemake.output.fuel_costs)
     fuel_cost_resampled = prepare_cost_timeseries(fuel_cost_df, time_res)
     fuel_cost_resampled.to_csv(snakemake.output.fuel_cost_timeseries)


### PR DESCRIPTION
This PR adds a new rule to the workflow that accesses time series cost data from the [PUDL project](https://data.catalyst.coop/pudl/out_eia923__monthly_fuel_receipts_costs?_sort=rowid&state__exact=IL#export). Merging this PR closes #29 and closes #30.

>[!IMPORTANT]
> After the reviewer(s) have approved the PR, please update the "end date" under the "projects" tab on the right hand side. You may need to expand the view by clicking "+2 more".

## How the data is processed
1. The cost data are downloaded and come in $/MMBTU on a monthly basis.
2. The data are multiplied by the appropriate heat rates to get fuel costs in $/MWh
3. NaN values are removed by linear interpolation.
4. The data are resampled to the appropriate hourly scale using a forward-fill strategy. 
5. Lastly, in the `add_electricity` rule, the VOM costs are added to each timestep.