### PR TITLE
Adds a script to run sensitivities

### DIFF
--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -18,7 +18,7 @@ def power_by_carrier(n):
         n.generators.carrier).sum().T 
     
     if not n.storage_units.empty:
-        sto = n.storage_units_t.p.T.groupby(
+        sto = n.storage_units_t.p.T.clip(lower=0).groupby(
             n.storage_units.carrier).sum().T
         p_by_carrier = pd.concat([p_by_carrier, sto], axis=1)
         

--- a/sensitivity-script.py
+++ b/sensitivity-script.py
@@ -32,8 +32,10 @@ variable_combinations = list(itertools.product(
 # ATB scenarios must be handled differently because sub-parameters can't be passed to snakemake in the command line
 atb_scenario_targets = ["scenario: \'Moderate\'", "scenario: \'Conservative\'", "scenario: \'Advanced\'"]
 
-# Function to modify the atb_params in the config file (from ChatGPT)
 def replace_strings_in_config(file_path, target_strings, new_value):
+"""
+This function to modifies the `atb_params` in the `config.yml` file (from ChatGPT).
+"""
     with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
 

--- a/sensitivity-script.py
+++ b/sensitivity-script.py
@@ -1,0 +1,70 @@
+import os
+import re
+import itertools
+import shutil
+
+# Path to the base config file
+base_config_file = "config.yml"
+backup_config_file = "config_backup.yml"
+
+# Backup the original config file to restore it later
+shutil.copyfile(base_config_file, backup_config_file)
+
+# Define the variables and their possible values
+variable_ranges = {
+    'fuel_cost_year': [2018,2019,2020,2021,2022,2023],
+    'load_growth': [0, 1],
+    'total_demand': [136e6, 185e6],
+    'atb_scenario': ['Conservative', 'Advanced']
+}
+
+# Create a string of all the rules that must be forced to run
+forcerun = "retrieve_costs retrieve_fuel_costs add_electricity"
+
+# Generate all possible combinations of the variables
+variable_combinations = list(itertools.product(
+    variable_ranges['fuel_cost_year'],
+    variable_ranges['load_growth'],
+    variable_ranges['total_demand'],
+    variable_ranges['atb_scenario']
+))
+
+# ATB scenarios must be handled differently because sub-parameters can't be passed to snakemake in the command line
+atb_scenario_targets = ["scenario: \'Moderate\'", "scenario: \'Conservative\'", "scenario: \'Advanced\'"]
+
+# Create a function (from ChatGPT) that will be used to modify the atb_params in the config file
+def replace_strings_in_config(file_path, target_strings, new_value):
+    with open(file_path, 'r', encoding='utf-8') as file:
+        content = file.read()
+
+    pattern = '|'.join(map(re.escape, target_strings))
+    updated_content = re.sub(pattern, new_value, content)
+
+    with open(file_path, 'w', encoding='utf-8') as file:
+        file.write(updated_content)
+
+run_no = 0
+for idx, (fuel_cost_year, load_growth, total_demand, atb_scenario) in enumerate(variable_combinations):
+    # Name the scenario
+    scenario = f"cost-{fuel_cost_year}_growth-{load_growth}_demand-{total_demand}_atb-{atb_scenario}"
+
+    # Combine all the top-line config variables
+    config = f"time_res=1 fuel_cost_year={fuel_cost_year} load_growth={load_growth} total_demand={total_demand} scenario={scenario}"
+
+    # Modify the config file to update the ATB scenario
+    atb_scenario_text = f"scenario: \'{atb_scenario}\'"
+    replace_strings_in_config(base_config_file, atb_scenario_targets, atb_scenario_text)
+
+    # Run Snakemake, passing the new variables as configuration
+    print(f"Running Snakemake with config {run_no}...")
+    print(f"snakemake --cores=4 --forcerun {forcerun} --config {config}")
+    os.system(f"snakemake --cores=4 --forcerun {forcerun} --config {config}")
+    run_no += 1
+
+    #for debugging:
+    #if run_no == 1: break
+
+# Restore the original base config after running all scenarios
+shutil.copyfile(backup_config_file, base_config_file)
+os.remove(backup_config_file)
+print("Restored the original config file.")

--- a/sensitivity-script.py
+++ b/sensitivity-script.py
@@ -12,14 +12,15 @@ shutil.copyfile(base_config_file, backup_config_file)
 
 # Define the variables and their possible values
 variable_ranges = {
-    'fuel_cost_year': [2018,2019,2020,2021,2022,2023],
+    'fuel_cost_year': [2018, 2019, 2020, 2021, 2022, 2023],
     'load_growth': [0, 1],
     'total_demand': [136e6, 185e6],
-    'atb_scenario': ['Moderate'] # 'Conservative', 'Advanced'
+    'atb_scenario': ['Moderate']  # 'Conservative', 'Advanced'
 }
 
 # Create a string of all the rules that must be forced to run
-forcerun = "retrieve_fuel_costs add_electricity" # add retrieve_costs when also modifying atb scenarios
+# NOTE: add retrieve_costs when also modifying atb scenarios
+forcerun = "retrieve_fuel_costs add_electricity"
 
 # Generate all possible combinations of the variables
 variable_combinations = list(itertools.product(
@@ -29,13 +30,20 @@ variable_combinations = list(itertools.product(
     variable_ranges['atb_scenario']
 ))
 
-# ATB scenarios must be handled differently because sub-parameters can't be passed to snakemake in the command line
-atb_scenario_targets = ["scenario: \'Moderate\'", "scenario: \'Conservative\'", "scenario: \'Advanced\'"]
+# ATB scenarios must be handled differently because sub-parameters can't be
+# passed to snakemake in the command line
+atb_scenario_targets = [
+    "scenario: \'Moderate\'",
+    "scenario: \'Conservative\'",
+    "scenario: \'Advanced\'"
+]
+
 
 def replace_strings_in_config(file_path, target_strings, new_value):
-"""
-This function to modifies the `atb_params` in the `config.yml` file (from ChatGPT).
-"""
+    """
+    This function looks for a list of target strings and replaces them with a
+    new value (from ChatGPT).
+    """
     with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
 
@@ -45,18 +53,39 @@ This function to modifies the `atb_params` in the `config.yml` file (from ChatGP
     with open(file_path, 'w', encoding='utf-8') as file:
         file.write(updated_content)
 
+
 run_no = 0
-for idx, (fuel_cost_year, load_growth, total_demand, atb_scenario) in enumerate(variable_combinations):
+for idx, (fuel_cost_year,
+          load_growth,
+          total_demand,
+          atb_scenario) in enumerate(variable_combinations):
+
     # Name the scenario
-    scenario = f"cost-{fuel_cost_year}_growth-{load_growth}_demand-{total_demand:.2E}_atb-{atb_scenario}"
+    scenario = (
+        f"cost-{fuel_cost_year}_"
+        f"growth-{load_growth}_"
+        f"demand-{total_demand:.2E}_"
+        f"atb-{atb_scenario}"
+    )
 
     # Combine all the top-line config variables
-    config = f"time_res=1 fuel_cost_year={fuel_cost_year} load_growth={load_growth} total_demand={total_demand} scenario={scenario}"
+    config = (
+        f"time_res=1 "
+        f"fuel_cost_year={fuel_cost_year} "
+        f"load_growth={load_growth} "
+        f"total_demand={total_demand} "
+        f"scenario={scenario}"
+    )
 
-    # Modify the config file to update the ATB scenario. 
-    # This is disabled because the model won't run -- alternate scenarios don't exist for nuclear
-    #atb_scenario_text = f"scenario: \'{atb_scenario}\'"
-    #replace_strings_in_config(base_config_file, atb_scenario_targets, atb_scenario_text)
+    # Modify the config file to update the ATB scenario.
+    # This is disabled because the model won't run --
+    # alternate scenarios don't exist for nuclear
+    # atb_scenario_text = f"scenario: \'{atb_scenario}\'"
+    # replace_strings_in_config(
+    #    base_config_file,
+    #    atb_scenario_targets,
+    #    atb_scenario_text
+    # )
 
     # Run Snakemake, passing the new variables as configs
     print(f"Running Snakemake with config {run_no} and the following command:")
@@ -65,7 +94,7 @@ for idx, (fuel_cost_year, load_growth, total_demand, atb_scenario) in enumerate(
     run_no += 1
 
     # for debugging:
-    #if run_no == 1: break
+    # if run_no == 1: break
 
 # Restore the original base config after running all scenarios
 shutil.copyfile(backup_config_file, base_config_file)

--- a/sensitivity-script.py
+++ b/sensitivity-script.py
@@ -61,7 +61,6 @@ for idx, (fuel_cost_year, load_growth, total_demand, atb_scenario) in enumerate(
     # Run Snakemake, passing the new variables as configs
     print(f"Running Snakemake with config {run_no} and the following command:")
     print(f"snakemake --cores=4 --forcerun {forcerun} --config {config}")
-    os.system("snakemake --delete-all-output --cores=1")    # this could probably be optimized to not delete everything
     os.system(f"snakemake --cores=4 --forcerun {forcerun} --config {config}")
     run_no += 1
 

--- a/sensitivity.md
+++ b/sensitivity.md
@@ -1,7 +1,7 @@
 # Variables to change for sensitivities
 
 - **Coal and methane prices.** Fuel prices are modeled as 12 values from a historical year, derived from this PUDL database: https://data.catalyst.coop/pudl/core_eia923__monthly_fuel_receipts_costs.
-- **ATB cases.** The model uses the 2022 ATB, which has three scenarios: "Moderate", "Conservative", and "Advanced". For sensitivity analysis we can ignore "Moderate" and just use "Conservative" and "Advanced".
+- **ATB cases.** The model uses the 2022 ATB, which has three scenarios: "Moderate", "Conservative", and "Advanced". We only use the "Moderate" case, here.
 - **Demand growth.** This will be modeled as either 0.00 or 1.00.
 - **Exports.** There's no toggle or setting for this -- rather the starting load determines whether or not the model is matching the in-state load or the in-state generation. For no export the starting value should be 136e6; for export it should be 185e6.
 

--- a/sensitivity.md
+++ b/sensitivity.md
@@ -24,4 +24,4 @@ The order in the snakemake workflow of the rules we need to modify:
 
 # Remove ATB cases
 
-There are no conservative or advanced cases for nuclear in the ATB which causes the model to crash. The simplest workaround is just to not do sensitivites on ATB scenarios.
+There are no conservative or advanced cases for nuclear in the ATB, only moderate. As a result the model won't run for cases other than moderate, and we did not include a sensitivity around capital cost in the model.

--- a/sensitivity.md
+++ b/sensitivity.md
@@ -1,0 +1,23 @@
+# Variables to change for sensitivities
+
+- **Coal and methane prices.** Fuel prices are modeled as 12 values from a historical year, derived from this PUDL database: https://data.catalyst.coop/pudl/core_eia923__monthly_fuel_receipts_costs.
+- **ATB cases.** The model uses the 2022 ATB, which has three scenarios: "Moderate", "Conservative", and "Advanced". For sensitivity analysis we can ignore "Moderate" and just use "Conservative" and "Advanced".
+- **Demand growth.** This will be modeled as either 0.00 or 1.00.
+- **Exports.** There's no toggle or setting for this -- rather the starting load determines whether or not the model is matching the in-state load or the in-state generation. For no export the starting value should be 136e6; for export it should be 185e6.
+
+| Parameter   | Variable in `config.yml`| Scripts                                       | Values                           |
+|-------------|-------------------------|-----------------------------------------------|----------------------------------|
+|Fuel prices  |`fuel_cost_year`         |`retrieve_fuel_prices.py`, `add_electricity.py`|2018, 2019, 2020, 2021, 2022, 2023|
+|ATB cases    |`scenario`               |`retrieve_costs.py`                            |"Conservative", "Advanced"        |
+|Demand growth|`load_growth`            |`add_electricity.py`                           |0.00, 1.00                        |
+|Exports      |`total_demand`           |`add_electricity.py`                           |136e6, 185e6                      |
+
+Total possibilities = 6x2x2x2 = 48
+
+The order in the snakemake workflow of the rules we need to modify:
+
+| Rule | Script                  |
+|------|-------------------------|
+|3     |`retrieve_costs.py`      |
+|4     |`retrieve_fuel_prices.py`|
+|11    |`add_electricity.py`     |

--- a/sensitivity.md
+++ b/sensitivity.md
@@ -21,3 +21,7 @@ The order in the snakemake workflow of the rules we need to modify:
 |3     |`retrieve_costs.py`      |
 |4     |`retrieve_fuel_prices.py`|
 |11    |`add_electricity.py`     |
+
+# Remove ATB cases
+
+There are no conservative or advanced cases for nuclear in the ATB which causes the model to crash. The simplest workaround is just to not do sensitivites on ATB scenarios.


### PR DESCRIPTION
This PR adds a script which runs sensitivities on the model by changing the source year for fuel cost data, the load growth, and the initial demand (a proxy for whether Illinois is a net exporter of electricity). 

To run the script, activate the environment and enter:
`python sensitivity-script.py`

The markdown file details what's being changed and why.

This also makes one small change to `plot_results.py`. The plot now shows only battery discharge, not the net of discharge and charge.